### PR TITLE
pass structured error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.npmrc

--- a/src/query/response/error.ts
+++ b/src/query/response/error.ts
@@ -1,0 +1,37 @@
+export const handleError = async (response: Response) => {
+  const responseText = await response.text();
+  const json = getJson(responseText);
+
+  if (json?.error) {
+    const error = json.error as ErrorResponse;
+    throw new QueryAgentError(error.message, error.code, error.details);
+  }
+
+  throw new Error(`Query agent failed. ${responseText}`);
+};
+
+const getJson = (responseText: string): Record<string, unknown> | null => {
+  try {
+    return JSON.parse(responseText);
+  } catch {
+    return null;
+  }
+};
+
+export class QueryAgentError extends Error {
+  constructor(
+    message: string,
+    public code: string,
+    public details?: Record<string, unknown>
+  ) {
+    super(message);
+    this.code = code;
+    this.details = details;
+  }
+}
+
+type ErrorResponse = {
+  message: string;
+  code: string;
+  details?: Record<string, unknown>;
+};

--- a/src/query/response/index.ts
+++ b/src/query/response/index.ts
@@ -1,1 +1,2 @@
 export * from "./response.js";
+export { QueryAgentError } from "./error.js";


### PR DESCRIPTION
Pass structured error so that readable error could be extracted by the consumer:
```
try {
  const result = await queryAgent.run("Any Apple laptops?");
} catch (error) {
  if (error instanceof QueryAgentError) {
    console.log(error.message);
  }
}
```