### PR TITLE
Handle errors during QA streaming

### DIFF
--- a/src/query/agent.ts
+++ b/src/query/agent.ts
@@ -119,14 +119,16 @@ export class QueryAgent {
 
     for await (const event of sseStream) {
       let output: ProgressMessage | StreamedTokens | QueryAgentResponse;
-      if (event.event === "progress_message") {
+      if (event.event === "error") {
+        throw new Error(`Query agent failed. ${event.data}`);
+      } else if (event.event === "progress_message") {
         output = mapProgressMessageFromSSE(event);
       } else if (event.event === "streamed_tokens") {
         output = mapStreamedTokensFromSSE(event);
       } else if (event.event === "final_state") {
         output = mapResponseFromSSE(event);
       } else {
-        throw new Error(`Unexpected event type: ${event.event}`);
+        throw new Error(`Unexpected event type: ${event.event}: ${event.data}`);
       }
       yield output;
     }

--- a/src/query/response/error.ts
+++ b/src/query/response/error.ts
@@ -1,5 +1,4 @@
-export const handleError = async (response: Response) => {
-  const responseText = await response.text();
+export const handleError = async (responseText: string) => {
   const json = getJson(responseText);
 
   if (json?.error) {


### PR DESCRIPTION
The current version of the QA streaming doesn't handle errors well, hiding the error message from the user (oops). Since errors are sent as SSEs, we just need to explicitly handle the `error` events. Now, error messages are visible, the same as with `run()`:

```
Error: QueryAgentError: Error while searching Weaviate collection
    at file:///Users/danjones/Documents/GitHub/agents-typescript-client/dist/query/response/error.js:14:15
    at Generator.next (<anonymous>)
    at file:///Users/danjones/Documents/GitHub/agents-typescript-client/dist/query/response/error.js:7:71
    at new Promise (<anonymous>)
    at __awaiter (file:///Users/danjones/Documents/GitHub/agents-typescript-client/dist/query/response/error.js:3:12)
    at handleError (file:///Users/danjones/Documents/GitHub/agents-typescript-client/dist/query/response/error.js:10:46)
    at QueryAgent.stream_1 (file:///Users/danjones/Documents/GitHub/agents-typescript-client/dist/query/agent.js:129:39)
    at stream_1.next (<anonymous>)
    at resume (file:///Users/danjones/Documents/GitHub/agents-typescript-client/dist/query/agent.js:24:44)
    at fulfill (file:///Users/danjones/Documents/GitHub/agents-typescript-client/dist/query/agent.js:26:31) {
  code: 'WEAVIATE_SEARCH_ERROR',
  details: {
    collection_name: 'SphereSmall',
    error: '<AioRpcError of RPC that terminated with:\n' +
      '\tstatus = StatusCode.UNKNOWN\n' +
      '\tdetails = "extract target vectors: class SphereSmall does not have named vector intentionally_wrong_vector configured. Available named vectors [text_vector]"\n' +
      '\tdebug_error_string = "UNKNOWN:Error received from peer  {grpc_message:"extract target vectors: class SphereSmall does not have named vector intentionally_wrong_vector configured. Available named vectors [text_vector]", grpc_status:2, created_time:"2025-06-19T15:34:27.66022+01:00"}"\n' +
      '>'
  }
}
```