### PR TITLE
Add option to skip final state when streaming QA

### DIFF
--- a/src/query/agent.ts
+++ b/src/query/agent.ts
@@ -97,6 +97,22 @@ export class QueryAgent {
    * @param options - Additional options for the run.
    * @returns The response from the query agent.
    */
+  stream(
+    query: string,
+    options: QueryAgentStreamOptions & { includeProgress: false; includeFinalState: false }
+  ): AsyncGenerator<StreamedTokens>;
+  stream(
+    query: string,
+    options: QueryAgentStreamOptions & { includeProgress: false; includeFinalState?: true }
+  ): AsyncGenerator<StreamedTokens | QueryAgentResponse>;
+  stream(
+    query: string,
+    options: QueryAgentStreamOptions & { includeProgress?: true; includeFinalState: false }
+  ): AsyncGenerator<ProgressMessage | StreamedTokens>;
+  stream(
+    query: string,
+    options?: QueryAgentStreamOptions & { includeProgress?: true; includeFinalState?: true }
+  ): AsyncGenerator<ProgressMessage | StreamedTokens | QueryAgentResponse>;
   async *stream(
     query: string,
     { collections, context, includeProgress, includeFinalState }: QueryAgentStreamOptions = {}

--- a/src/query/agent.ts
+++ b/src/query/agent.ts
@@ -99,7 +99,7 @@ export class QueryAgent {
    */
   async *stream(
     query: string,
-    { collections, context, includeProgress }: QueryAgentStreamOptions = {}
+    { collections, context, includeProgress, includeFinalState }: QueryAgentStreamOptions = {}
   ): AsyncGenerator<ProgressMessage | StreamedTokens | QueryAgentResponse> {
     const targetCollections = collections ?? this.collections;
 
@@ -126,6 +126,7 @@ export class QueryAgent {
           system_prompt: this.systemPrompt,
           previous_response: context ? mapApiResponse(context) : undefined,
           include_progress: includeProgress ?? true,
+          include_final_state: includeFinalState ?? true,
         }),
       }
     );
@@ -177,4 +178,6 @@ export type QueryAgentStreamOptions = {
   context?: QueryAgentResponse;
   /** Include progress messages in the stream. */
   includeProgress?: boolean;
+  /** Include final state in the stream. */
+  includeFinalState?: boolean;
 };


### PR DESCRIPTION
This adds a new option to the QA streaming to skip the final state being yielded. Also adds type overloading to the stream method so that the output types are correctly narrowed depending on `includeProgress` and `includeFinalState`, e.g.,
<img width="565" alt="qa_overload_ts" src="https://github.com/user-attachments/assets/20849893-1567-418b-ac04-d49ab5c99d5d" />
