### PR TITLE
Add tenant option to QueryAgentCollectionConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weaviate-agents",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "JS/TS client for Weaviate Agents",
   "exports": "./dist/index.js",
   "type": "module",

--- a/src/query/collection.ts
+++ b/src/query/collection.ts
@@ -8,6 +8,7 @@ export const mapCollections = (
           name: collection.name,
           view_properties: collection.viewProperties,
           target_vector: collection.targetVector,
+          tenant: collection.tenant,
         }
   );
 
@@ -15,6 +16,8 @@ export const mapCollections = (
 export type QueryAgentCollectionConfig = {
   /** The name of the collection to query. */
   name: string;
+  /** Tenant for the collection if multi-tenancy is enabled. */
+  tenant?: string;
   /** List of of property names the agent has the ability to view for the collection. */
   viewProperties?: string[];
   /** Target vector for the query if a collection uses named vector. */


### PR DESCRIPTION
Adds the `tenant` option to QueryAgentCollectionConfig, to enable queries on collections with multi-tenancy.