### PR TITLE
Add Follow-Up Queries in Suggest Queries Mode

### DIFF
--- a/src/query/agent.test.ts
+++ b/src/query/agent.test.ts
@@ -849,6 +849,99 @@ it("suggest queries mode uses constructor collections", async () => {
   ]);
 });
 
+it("suggest queries with conversation includes conversation_context in request body", async () => {
+  const mockClient = {
+    getConnectionDetails: jest.fn().mockResolvedValue({
+      host: "test-cluster",
+      bearerToken: "test-token",
+      headers: { "X-Provider": "test-key" },
+    }),
+  } as unknown as WeaviateClient;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const capturedBodies: any[] = [];
+
+  const apiSuccess: ApiSuggestQueryResponse = {
+    queries: [{ query: "Follow-up query" }],
+    collection_count: 1,
+    usage: {
+      model_units: 1,
+      usage_in_plan: true,
+      remaining_plan_requests: 10,
+    },
+    total_time: 0.4,
+  };
+
+  global.fetch = jest.fn((url, init?: RequestInit) => {
+    if (init && init.body) {
+      capturedBodies.push(JSON.parse(init.body as string));
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(apiSuccess),
+    } as Response);
+  }) as jest.Mock;
+
+  const agent = new QueryAgent(mockClient);
+
+  await agent.suggestQueries({
+    collections: ["test_collection"],
+    conversation: [
+      { role: "user", content: "What topics are covered?" },
+      { role: "assistant", content: "The collection covers ML and economics." },
+    ],
+  });
+
+  expect(capturedBodies[0].conversation_context).toEqual({
+    messages: [
+      { role: "user", content: "What topics are covered?" },
+      { role: "assistant", content: "The collection covers ML and economics." },
+    ],
+  });
+});
+
+it("suggest queries without conversation omits conversation_context from request body", async () => {
+  const mockClient = {
+    getConnectionDetails: jest.fn().mockResolvedValue({
+      host: "test-cluster",
+      bearerToken: "test-token",
+      headers: { "X-Provider": "test-key" },
+    }),
+  } as unknown as WeaviateClient;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const capturedBodies: any[] = [];
+
+  const apiSuccess: ApiSuggestQueryResponse = {
+    queries: [{ query: "Test query" }],
+    collection_count: 1,
+    usage: {
+      model_units: 1,
+      usage_in_plan: true,
+      remaining_plan_requests: 10,
+    },
+    total_time: 0.3,
+  };
+
+  global.fetch = jest.fn((url, init?: RequestInit) => {
+    if (init && init.body) {
+      capturedBodies.push(JSON.parse(init.body as string));
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(apiSuccess),
+    } as Response);
+  }) as jest.Mock;
+
+  const agent = new QueryAgent(mockClient);
+
+  await agent.suggestQueries({
+    collections: ["test_collection"],
+  });
+
+  expect(capturedBodies[0].conversation_context).toBeUndefined();
+});
+
 it("suggest queries mode failure propagates QueryAgentError", async () => {
   const mockClient = {
     getConnectionDetails: jest.fn().mockResolvedValue({

--- a/src/query/agent.test.ts
+++ b/src/query/agent.test.ts
@@ -537,6 +537,159 @@ it("search-only mode failure propagates QueryAgentError", async () => {
   }
 });
 
+it("search-only mode sends retrieval_strategy and persists through pagination", async () => {
+  const mockClient = {
+    getConnectionDetails: jest.fn().mockResolvedValue({
+      host: "test-cluster",
+      bearerToken: "test-token",
+      headers: { "X-Provider": "test-key" },
+    }),
+  } as unknown as WeaviateClient;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const capturedBodies: any[] = [];
+
+  const apiSuccess: ApiSearchModeResponse = {
+    searches: [
+      {
+        query: "search query",
+        collection: "test_collection",
+      },
+    ],
+    usage: {
+      model_units: 1,
+      usage_in_plan: true,
+      remaining_plan_requests: 2,
+    },
+    total_time: 1.0,
+    search_results: { objects: [] },
+  };
+
+  global.fetch = jest.fn((url, init?: RequestInit) => {
+    if (init && init.body) {
+      capturedBodies.push(JSON.parse(init.body as string));
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(apiSuccess),
+    } as Response);
+  }) as jest.Mock;
+
+  const agent = new QueryAgent(mockClient);
+
+  const first = await agent.search("test query", {
+    collections: ["test_collection"],
+    retrievalStrategy: "precision",
+  });
+
+  // First request should include retrieval_strategy
+  expect(capturedBodies[0].retrieval_strategy).toBe("precision");
+
+  // Paginated request should also include retrieval_strategy
+  await first.next({ limit: 20, offset: 1 });
+  expect(capturedBodies[1].retrieval_strategy).toBe("precision");
+});
+
+it("search-only mode defaults retrieval_strategy to recall", async () => {
+  const mockClient = {
+    getConnectionDetails: jest.fn().mockResolvedValue({
+      host: "test-cluster",
+      bearerToken: "test-token",
+      headers: { "X-Provider": "test-key" },
+    }),
+  } as unknown as WeaviateClient;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const capturedBodies: any[] = [];
+
+  const apiSuccess: ApiSearchModeResponse = {
+    searches: [
+      {
+        query: "search query",
+        collection: "test_collection",
+      },
+    ],
+    usage: {
+      model_units: 1,
+      usage_in_plan: true,
+      remaining_plan_requests: 2,
+    },
+    total_time: 1.0,
+    search_results: { objects: [] },
+  };
+
+  global.fetch = jest.fn((url, init?: RequestInit) => {
+    if (init && init.body) {
+      capturedBodies.push(JSON.parse(init.body as string));
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(apiSuccess),
+    } as Response);
+  }) as jest.Mock;
+
+  const agent = new QueryAgent(mockClient);
+
+  await agent.search("test query", {
+    collections: ["test_collection"],
+  });
+
+  // Default should be "recall"
+  expect(capturedBodies[0].retrieval_strategy).toBe("recall");
+});
+
+it("search-only mode caches empty searches array for precision mode pagination", async () => {
+  const mockClient = {
+    getConnectionDetails: jest.fn().mockResolvedValue({
+      host: "test-cluster",
+      bearerToken: "test-token",
+      headers: { "X-Provider": "test-key" },
+    }),
+  } as unknown as WeaviateClient;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const capturedBodies: any[] = [];
+
+  // Precision mode can return an empty searches array
+  const apiSuccess: ApiSearchModeResponse = {
+    searches: [],
+    usage: {
+      model_units: 1,
+      usage_in_plan: true,
+      remaining_plan_requests: 2,
+    },
+    total_time: 1.0,
+    search_results: { objects: [] },
+  };
+
+  global.fetch = jest.fn((url, init?: RequestInit) => {
+    if (init && init.body) {
+      capturedBodies.push(JSON.parse(init.body as string));
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(apiSuccess),
+    } as Response);
+  }) as jest.Mock;
+
+  const agent = new QueryAgent(mockClient);
+
+  const first = await agent.search("test query", {
+    collections: ["test_collection"],
+    retrievalStrategy: "precision",
+  });
+
+  // First request should have searches: null (generation request)
+  expect(capturedBodies[0].searches).toBeNull();
+  expect(capturedBodies[0].system_prompt).not.toBeUndefined();
+
+  // Second request should use the cached empty array, not re-send as generation request
+  await first.next({ limit: 20, offset: 1 });
+  expect(capturedBodies[1].searches).toEqual([]);
+  // Should NOT have system_prompt — that's only on the initial generation request
+  expect(capturedBodies[1].system_prompt).toBeUndefined();
+});
+
 it("suggest queries mode success", async () => {
   const mockClient = {
     getConnectionDetails: jest.fn().mockResolvedValue({

--- a/src/query/agent.ts
+++ b/src/query/agent.ts
@@ -418,6 +418,8 @@ export class QueryAgent {
    * @param options.diversityWeight - Optional number between `0.0` and `1.0` to diversify results
    *   with MMR reranking. Higher values push for more topical variety at the cost of relevance.
    *   Defaults to no diversity.
+   * @param options.retrievalStrategy - The retrieval strategy: `"recall"` for broader retrieval or
+   *   `"precision"` for more targeted results. Defaults to `"recall"`.
    * @returns A {@link SearchModeResponse} for the first page of results. Use
    *   `response.next({ limit, offset })` to paginate.
    *
@@ -435,6 +437,7 @@ export class QueryAgent {
       limit = 20,
       collections,
       diversityWeight,
+      retrievalStrategy = "recall",
     }: QueryAgentSearchOnlyOptions = {},
   ): Promise<SearchModeResponse> {
     const searcher = new QueryAgentSearcher(
@@ -444,6 +447,7 @@ export class QueryAgent {
       this.systemPrompt,
       this.agentsHost,
       diversityWeight,
+      retrievalStrategy,
     );
 
     return searcher.run({ limit, offset: 0 });
@@ -634,6 +638,12 @@ export type QueryAgentSearchOnlyOptions = {
    * push for more topical variety at the cost of relevance. Defaults to no diversity.
    */
   diversityWeight?: number;
+  /**
+   * The retrieval strategy to use for the search. `"recall"` optimizes for finding all relevant
+   * results (broader retrieval), while `"precision"` optimizes for accuracy of returned results
+   * (narrower, more targeted retrieval). Defaults to `"recall"`.
+   */
+  retrievalStrategy?: "recall" | "precision";
 };
 
 /** Options for {@link QueryAgent.suggestQueries}. */

--- a/src/query/agent.ts
+++ b/src/query/agent.ts
@@ -466,6 +466,9 @@ export class QueryAgent {
    * @param options.numQueries - The number of queries to suggest. Defaults to 3.
    * @param options.instructions - Optional natural language guidance for the style, topic, or
    *   language of the suggested queries. Supplied in addition to the agent's system instructions.
+   * @param options.conversation - Optional conversation history to contextualise suggested queries
+   *   as follow-up questions. When provided, the agent will generate suggestions that continue the
+   *   conversation naturally.
    * @returns A {@link SuggestQueryResponse} containing the list of suggested queries, along with
    *   additional metadata if present.
    *
@@ -476,6 +479,10 @@ export class QueryAgent {
    *   collections: ["Products"],
    *   numQueries: 5,
    *   instructions: "Focus on questions about eco-friendly features.",
+   *   conversation: [
+   *     { role: "user", content: "What topics are covered?" },
+   *     { role: "assistant", content: "The collection covers ML and economics." },
+   *   ],
    * });
    * ```
    */
@@ -483,6 +490,7 @@ export class QueryAgent {
     collections,
     numQueries,
     instructions,
+    conversation,
   }: QueryAgentSuggestQueriesOptions = {}): Promise<SuggestQueryResponse> {
     const targetCollections = this.validateCollections(collections);
     const { requestHeaders, connectionHeaders } = await getHeaders(this.client);
@@ -494,6 +502,9 @@ export class QueryAgent {
     };
     if (instructions !== undefined) {
       body.instructions = instructions;
+    }
+    if (conversation !== undefined) {
+      body.conversation_context = { messages: conversation };
     }
 
     const response = await fetch(`${this.agentsHost}/query/suggest_queries`, {
@@ -660,4 +671,9 @@ export type QueryAgentSuggestQueriesOptions = {
    * Supplied in addition to the agent's system instructions.
    */
   instructions?: string;
+  /**
+   * Optional conversation history to contextualise suggested queries as follow-up questions.
+   * When provided, the agent will generate suggestions that continue the conversation naturally.
+   */
+  conversation?: ChatMessage[];
 };

--- a/src/query/search.ts
+++ b/src/query/search.ts
@@ -28,6 +28,7 @@ export class QueryAgentSearcher {
     private systemPrompt: string | undefined,
     private agentsHost: string,
     private diversityWeight: number | undefined,
+    private retrievalStrategy: "recall" | "precision",
   ) {}
 
   private buildRequestBody(
@@ -49,11 +50,13 @@ export class QueryAgentSearcher {
         searches: null,
         system_prompt: this.systemPrompt || null,
         diversity_weight: this.diversityWeight ?? null,
+        retrieval_strategy: this.retrievalStrategy,
       };
     }
     return {
       ...base,
       searches: this.cachedSearches,
+      retrieval_strategy: this.retrievalStrategy,
     };
   }
 
@@ -94,7 +97,7 @@ export class QueryAgentSearcher {
     // If we successfully mapped the searches, cache them for the next request.
     // Since this cache is a private internal value, there's not point in mapping
     // back and forth between the exported and API types, so we cache apiSearches
-    if (mappedResponse.searches) {
+    if (mappedResponse.searches !== undefined) {
       this.cachedSearches = apiSearches;
     }
     return {


### PR DESCRIPTION
_Sample Usage:_

```TypeScript
const suggestions = await qa.suggestQueries({
  conversation: [
    { role: "user", content: "What topics are covered?" },
    { role: "assistant", content: "The collection covers ML and economics." },
  ],
});

console.log(suggestions.queries);
```