### PR TITLE
Add `effort` to Search Mode

### DIFF
--- a/src/query/agent.test.ts
+++ b/src/query/agent.test.ts
@@ -693,7 +693,7 @@ it("search-only mode sends effort and persists through pagination", async () => 
   expect(capturedBodies[1].effort).toBe("high");
 });
 
-it("search-only mode defaults effort to null when not provided", async () => {
+it("search-only mode omits effort when not provided", async () => {
   const mockClient = {
     getConnectionDetails: jest.fn().mockResolvedValue({
       host: "test-cluster",
@@ -737,8 +737,8 @@ it("search-only mode defaults effort to null when not provided", async () => {
     collections: ["test_collection"],
   });
 
-  // When no effort is specified, it should be sent as null (server-side default)
-  expect(capturedBodies[0].effort).toBeNull();
+  // When no effort is specified, it should not be sent (server-side default)
+  expect(capturedBodies[0].effort).toBeUndefined();
 });
 
 it("search-only mode caches empty searches array for precision mode pagination", async () => {

--- a/src/query/agent.test.ts
+++ b/src/query/agent.test.ts
@@ -640,6 +640,107 @@ it("search-only mode defaults filtering to recall", async () => {
   expect(capturedBodies[0].filtering).toBeUndefined();
 });
 
+it("search-only mode sends effort and persists through pagination", async () => {
+  const mockClient = {
+    getConnectionDetails: jest.fn().mockResolvedValue({
+      host: "test-cluster",
+      bearerToken: "test-token",
+      headers: { "X-Provider": "test-key" },
+    }),
+  } as unknown as WeaviateClient;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const capturedBodies: any[] = [];
+
+  const apiSuccess: ApiSearchModeResponse = {
+    searches: [
+      {
+        query: "search query",
+        collection: "test_collection",
+      },
+    ],
+    usage: {
+      model_units: 1,
+      usage_in_plan: true,
+      remaining_plan_requests: 2,
+    },
+    total_time: 1.0,
+    search_results: { objects: [] },
+  };
+
+  global.fetch = jest.fn((url, init?: RequestInit) => {
+    if (init && init.body) {
+      capturedBodies.push(JSON.parse(init.body as string));
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(apiSuccess),
+    } as Response);
+  }) as jest.Mock;
+
+  const agent = new QueryAgent(mockClient);
+
+  const first = await agent.search("test query", {
+    collections: ["test_collection"],
+    effort: "high",
+  });
+
+  // First request should include effort
+  expect(capturedBodies[0].effort).toBe("high");
+
+  // Paginated request should also include effort
+  await first.next({ limit: 20, offset: 1 });
+  expect(capturedBodies[1].effort).toBe("high");
+});
+
+it("search-only mode defaults effort to null when not provided", async () => {
+  const mockClient = {
+    getConnectionDetails: jest.fn().mockResolvedValue({
+      host: "test-cluster",
+      bearerToken: "test-token",
+      headers: { "X-Provider": "test-key" },
+    }),
+  } as unknown as WeaviateClient;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const capturedBodies: any[] = [];
+
+  const apiSuccess: ApiSearchModeResponse = {
+    searches: [
+      {
+        query: "search query",
+        collection: "test_collection",
+      },
+    ],
+    usage: {
+      model_units: 1,
+      usage_in_plan: true,
+      remaining_plan_requests: 2,
+    },
+    total_time: 1.0,
+    search_results: { objects: [] },
+  };
+
+  global.fetch = jest.fn((url, init?: RequestInit) => {
+    if (init && init.body) {
+      capturedBodies.push(JSON.parse(init.body as string));
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(apiSuccess),
+    } as Response);
+  }) as jest.Mock;
+
+  const agent = new QueryAgent(mockClient);
+
+  await agent.search("test query", {
+    collections: ["test_collection"],
+  });
+
+  // When no effort is specified, it should be sent as null (server-side default)
+  expect(capturedBodies[0].effort).toBeNull();
+});
+
 it("search-only mode caches empty searches array for precision mode pagination", async () => {
   const mockClient = {
     getConnectionDetails: jest.fn().mockResolvedValue({

--- a/src/query/agent.ts
+++ b/src/query/agent.ts
@@ -606,6 +606,9 @@ export class QueryAgent {
    *   Defaults to no diversity.
    * @param options.filtering - The filtering strategy: `"recall"` for broader retrieval or
    *   `"precision"` for more targeted results. Defaults to `"recall"`.
+   * @param options.effort - The amount of effort the agent should put into the search. One of
+   *   `"low"`, `"medium"`, or `"high"`. Higher effort may improve result quality at the expense
+   *   of increased latency and cost.
    * @returns A {@link SearchModeResponse} for the first page of results. Use
    *   `response.next({ limit, offset })` to paginate.
    *
@@ -624,6 +627,7 @@ export class QueryAgent {
       collections,
       diversityWeight,
       filtering,
+      effort,
     }: QueryAgentSearchOnlyOptions = {},
   ): Promise<SearchModeResponse> {
     const searcher = new QueryAgentSearcher(
@@ -634,6 +638,7 @@ export class QueryAgent {
       this.agentsHost,
       diversityWeight,
       filtering,
+      effort,
     );
 
     return searcher.run({ limit, offset: 0 });
@@ -857,6 +862,12 @@ export type QueryAgentSearchOnlyOptions = {
    * (narrower, more targeted retrieval).
    */
   filtering?: "recall" | "precision";
+  /**
+   * The amount of effort the agent should put into the search. One of `"low"`, `"medium"`, or
+   * `"high"`. Higher effort may improve result quality at the expense of increased latency and
+   * cost.
+   */
+  effort?: "low" | "medium" | "high";
 };
 
 /** Options for {@link QueryAgent.suggestQueries}. */

--- a/src/query/search.ts
+++ b/src/query/search.ts
@@ -44,7 +44,6 @@ export class QueryAgentSearcher {
       collections: mapCollections(this.collections),
       limit,
       offset,
-      effort: this.effort ?? null,
     } as const;
     if (this.cachedSearches === undefined) {
       return {
@@ -53,12 +52,14 @@ export class QueryAgentSearcher {
         system_prompt: this.systemPrompt || null,
         diversity_weight: this.diversityWeight ?? null,
         ...(this.filtering !== undefined && { filtering: this.filtering }),
+        ...(this.effort !== undefined && { effort: this.effort }),
       };
     }
     return {
       ...base,
       searches: this.cachedSearches,
       ...(this.filtering !== undefined && { filtering: this.filtering }),
+      ...(this.effort !== undefined && { effort: this.effort }),
     };
   }
 

--- a/src/query/search.ts
+++ b/src/query/search.ts
@@ -29,6 +29,7 @@ export class QueryAgentSearcher {
     private agentsHost: string,
     private diversityWeight: number | undefined,
     private filtering: "recall" | "precision" | undefined,
+    private effort: "low" | "medium" | "high" | undefined,
   ) {}
 
   private buildRequestBody(
@@ -43,6 +44,7 @@ export class QueryAgentSearcher {
       collections: mapCollections(this.collections),
       limit,
       offset,
+      effort: this.effort ?? null,
     } as const;
     if (this.cachedSearches === undefined) {
       return {


### PR DESCRIPTION
## Summary

Adds an optional `effort` argument to the Query Agent's search-only mode, mirroring the equivalent change in the Python client (weaviate/weaviate-agents-python-client#99).

```ts
const response = await agent.search("What are Setwise Rerankers?", {
  effort: "high",
});
```

`effort` accepts `"low"`, `"medium"`, or `"high"`. Higher effort may improve result quality at the expense of increased latency and cost. The option is sent as a top-level `effort` field in the JSON body of requests to the `/search_only` endpoint.

## Changes

- **`src/query/agent.ts`**: Added `effort?: "low" | "medium" | "high"` to `QueryAgentSearchOnlyOptions` and passed it through `QueryAgent.search()` to the searcher, with doc comments matching the Python docstring.
- **`src/query/search.ts`**: `QueryAgentSearcher` stores `effort` at construction time and includes it in both the initial generation request and the cached-searches execution request, following the same conditional pattern as `filtering`, so it persists across `response.next()` pagination calls.
- **`src/query/agent.test.ts`**: Added tests covering that `effort` is included in the request body when set, persists through pagination, and is omitted from the request body when not provided.

## Backwards compatibility

The argument is optional. When omitted it is not included in the request body, so the server applies its default behavior and existing callers are unaffected.

## Testing

- `pnpm test`: 20/20 passing, including the two new tests
- `pnpm lint`, `pnpm format`, `pnpm build`: all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
